### PR TITLE
Recursively retrieve resource pages.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+
+# Declare files that will always have CRLF line endings on checkout.
+index.js text eol=lf
+
+# Denote all files that are truly binary and should not be modified.


### PR DESCRIPTION
The CF API automatically adds a maximum number of resources that can be
retrieved per request, and it can't be disabled.  This change loops to get
every page and aggregate into one.

Additional change: Git will now automatically convert file to LF, not CRLF).